### PR TITLE
perf: add benchmarks and optimize value access

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,41 @@
+# Benchmarks
+
+This directory contains paired benchmark programs for the pseudocode
+interpreter and Python 3.14.
+
+Run the full suite:
+
+```sh
+python3.14 benchmark/run_benchmarks.py
+```
+
+Run one benchmark:
+
+```sh
+python3.14 benchmark/run_benchmarks.py --bench cpu_arithmetic
+```
+
+The runner builds `shell`, executes each `.ps` program and matching `.py`
+program, verifies that stdout matches, then reports median wall time across the
+requested iterations. On macOS it also reports peak resident memory using
+`/usr/bin/time -l`.
+
+Latest local result on Python 3.14.5, 3 iterations, 1 warmup:
+
+| benchmark | output | pseudo | Python 3.14 | slowdown | pseudo RSS | Python RSS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| cpu_arithmetic | 9599988 | 0.2205s | 0.0314s | 7.0x | 27.6 MiB | 14.5 MiB |
+| recursive_fib | 46368 | 0.1994s | 0.0238s | 8.4x | 2.2 MiB | 14.5 MiB |
+| function_calls | 982568 | 0.0997s | 0.0238s | 4.2x | 9.7 MiB | 14.4 MiB |
+| array_memory | 25194337 | 0.0907s | 0.0260s | 3.5x | 16.3 MiB | 15.9 MiB |
+| array_push_pop | 24896907 | 0.1011s | 0.0255s | 4.0x | 15.5 MiB | 16.1 MiB |
+| string_concat | 20000 | 0.0406s | 0.0236s | 1.7x | 225.0 MiB | 14.6 MiB |
+
+Notes:
+
+- Timings include process startup for both executables.
+- `recursive_fib` mainly measures function call and recursion overhead.
+- `array_memory` exercises resize, indexed writes, indexed reads, and integer
+  arithmetic.
+- `array_push_pop` exercises dynamic array growth and shrinking.
+- `string_concat` prints only the loop count, but still builds the string.

--- a/benchmark/pseudo/array_memory.ps
+++ b/benchmark/pseudo/array_memory.ps
@@ -1,0 +1,10 @@
+n <- 50000
+arr <- {}
+arr.resize(n)
+for i <- 1 to n do
+    arr[i] <- (i * 13) % 1009
+
+sum <- 0
+for i <- 1 to n do
+    sum <- (sum + arr[i]) % 1000000007
+print(sum)

--- a/benchmark/pseudo/array_push_pop.ps
+++ b/benchmark/pseudo/array_push_pop.ps
@@ -1,0 +1,9 @@
+n <- 50000
+arr <- {}
+for i <- 1 to n do
+    arr.push((i * 19) % 997)
+
+sum <- 0
+for i <- 1 to n do
+    sum <- (sum + arr.pop()) % 1000000007
+print(sum)

--- a/benchmark/pseudo/cpu_arithmetic.ps
+++ b/benchmark/pseudo/cpu_arithmetic.ps
@@ -1,0 +1,5 @@
+n <- 200000
+acc <- 0
+for i <- 1 to n do
+    acc <- (acc + (i * 17) % 97) % 1000000007
+print(acc)

--- a/benchmark/pseudo/function_calls.ps
+++ b/benchmark/pseudo/function_calls.ps
@@ -1,0 +1,8 @@
+Algorithm mix(x):
+    return (x * 3 + 7) % 1000003
+
+n <- 60000
+acc <- 1
+for i <- 1 to n do
+    acc <- mix(acc + i)
+print(acc)

--- a/benchmark/pseudo/recursive_fib.ps
+++ b/benchmark/pseudo/recursive_fib.ps
@@ -1,0 +1,5 @@
+Algorithm fib(n):
+    if n <= 1 then return n
+    return fib(n - 1) + fib(n - 2)
+
+print(fib(24))

--- a/benchmark/pseudo/string_concat.ps
+++ b/benchmark/pseudo/string_concat.ps
@@ -1,0 +1,5 @@
+n <- 20000
+s <- ""
+for i <- 1 to n do
+    s <- s + "x"
+print(n)

--- a/benchmark/python/array_memory.py
+++ b/benchmark/python/array_memory.py
@@ -1,0 +1,9 @@
+n = 50000
+arr = [None] * n
+for i in range(1, n + 1):
+    arr[i - 1] = (i * 13) % 1009
+
+total = 0
+for i in range(1, n + 1):
+    total = (total + arr[i - 1]) % 1_000_000_007
+print(total)

--- a/benchmark/python/array_push_pop.py
+++ b/benchmark/python/array_push_pop.py
@@ -1,0 +1,9 @@
+n = 50000
+arr = []
+for i in range(1, n + 1):
+    arr.append((i * 19) % 997)
+
+total = 0
+for _ in range(1, n + 1):
+    total = (total + arr.pop()) % 1_000_000_007
+print(total)

--- a/benchmark/python/cpu_arithmetic.py
+++ b/benchmark/python/cpu_arithmetic.py
@@ -1,0 +1,5 @@
+n = 200000
+acc = 0
+for i in range(1, n + 1):
+    acc = (acc + (i * 17) % 97) % 1_000_000_007
+print(acc)

--- a/benchmark/python/function_calls.py
+++ b/benchmark/python/function_calls.py
@@ -1,0 +1,9 @@
+def mix(x):
+    return (x * 3 + 7) % 1_000_003
+
+
+n = 60000
+acc = 1
+for i in range(1, n + 1):
+    acc = mix(acc + i)
+print(acc)

--- a/benchmark/python/recursive_fib.py
+++ b/benchmark/python/recursive_fib.py
@@ -1,0 +1,7 @@
+def fib(n):
+    if n <= 1:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+
+print(fib(24))

--- a/benchmark/python/string_concat.py
+++ b/benchmark/python/string_concat.py
@@ -1,0 +1,5 @@
+n = 20000
+s = ""
+for _ in range(1, n + 1):
+    s = s + "x"
+print(n)

--- a/benchmark/run_benchmarks.py
+++ b/benchmark/run_benchmarks.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3.14
 import argparse
 import os
+import platform
 import re
 import shutil
 import statistics
@@ -39,7 +40,9 @@ def parse_args():
 
 
 def run_command(command):
-    time_bin = shutil.which("time")
+    time_bin = "/usr/bin/time" if platform.system() == "Darwin" else None
+    if time_bin and not Path(time_bin).exists():
+        time_bin = shutil.which("time")
     if time_bin:
         wrapped = [time_bin, "-l", *command]
         start = time.perf_counter()

--- a/benchmark/run_benchmarks.py
+++ b/benchmark/run_benchmarks.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3.14
+import argparse
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PSEUDO_DIR = ROOT / "benchmark" / "pseudo"
+PYTHON_DIR = ROOT / "benchmark" / "python"
+
+BENCHMARKS = [
+    "cpu_arithmetic",
+    "recursive_fib",
+    "function_calls",
+    "array_memory",
+    "array_push_pop",
+    "string_concat",
+]
+
+MAX_RSS_RE = re.compile(r"^\s*(\d+)\s+maximum resident set size", re.MULTILINE)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Compare PseudoCodeInterpreter benchmark programs with Python 3.14."
+    )
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--python", default="python3.14")
+    parser.add_argument("--shell", default=str(ROOT / "shell"))
+    parser.add_argument("--bench", choices=BENCHMARKS, action="append")
+    return parser.parse_args()
+
+
+def run_command(command):
+    time_bin = shutil.which("time")
+    if time_bin:
+        wrapped = [time_bin, "-l", *command]
+        start = time.perf_counter()
+        proc = subprocess.run(
+            wrapped,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        elapsed = time.perf_counter() - start
+        match = MAX_RSS_RE.search(proc.stderr)
+        max_rss = int(match.group(1)) if match else None
+        stderr = MAX_RSS_RE.sub("", proc.stderr).strip()
+    else:
+        start = time.perf_counter()
+        proc = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        elapsed = time.perf_counter() - start
+        max_rss = None
+        stderr = proc.stderr.strip()
+
+    if proc.returncode != 0:
+        joined = " ".join(command)
+        raise RuntimeError(
+            f"{joined} exited with {proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{stderr}"
+        )
+
+    return proc.stdout.rstrip("\n"), elapsed, max_rss
+
+
+def measure(label, command, warmups, iterations):
+    output = None
+    for _ in range(warmups):
+        output, _, _ = run_command(command)
+
+    times = []
+    rss_values = []
+    for _ in range(iterations):
+        output, elapsed, max_rss = run_command(command)
+        times.append(elapsed)
+        if max_rss is not None:
+            rss_values.append(max_rss)
+
+    return {
+        "label": label,
+        "output": output,
+        "median": statistics.median(times),
+        "min": min(times),
+        "max": max(times),
+        "rss": max(rss_values) if rss_values else None,
+    }
+
+
+def format_time(seconds):
+    return f"{seconds:.4f}s"
+
+
+def format_rss(value):
+    if value is None:
+        return "n/a"
+    # macOS /usr/bin/time -l reports bytes.
+    return f"{value / (1024 * 1024):.1f} MiB"
+
+
+def output_digest(output):
+    if len(output) <= 80:
+        return output
+    return f"{len(output)} chars"
+
+
+def main():
+    args = parse_args()
+    benches = args.bench or BENCHMARKS
+
+    subprocess.run(["make"], cwd=ROOT, check=True)
+
+    shell = Path(args.shell)
+    if not shell.exists():
+        raise FileNotFoundError(shell)
+
+    rows = []
+    for name in benches:
+        pseudo_file = PSEUDO_DIR / f"{name}.ps"
+        python_file = PYTHON_DIR / f"{name}.py"
+        pseudo = measure(
+            "pseudo",
+            [str(shell), str(pseudo_file)],
+            args.warmups,
+            args.iterations,
+        )
+        python = measure(
+            "python",
+            [args.python, str(python_file)],
+            args.warmups,
+            args.iterations,
+        )
+
+        if pseudo["output"] != python["output"]:
+            raise AssertionError(
+                f"{name} output mismatch\npseudo: {pseudo['output']!r}\npython: {python['output']!r}"
+            )
+
+        rows.append((name, pseudo, python))
+
+    print(f"Python: {subprocess.check_output([args.python, '--version'], text=True).strip()}")
+    print(f"Iterations: {args.iterations}, warmups: {args.warmups}")
+    print()
+    print(
+        f"{'benchmark':<16} {'output':<12} {'pseudo':>10} {'python':>10} "
+        f"{'slowdown':>10} {'pseudo rss':>12} {'python rss':>12}"
+    )
+    print("-" * 91)
+    for name, pseudo, python in rows:
+        slowdown = pseudo["median"] / python["median"]
+        print(
+            f"{name:<16} {output_digest(pseudo['output']):<12} "
+            f"{format_time(pseudo['median']):>10} {format_time(python['median']):>10} "
+            f"{slowdown:>9.1f}x {format_rss(pseudo['rss']):>12} {format_rss(python['rss']):>12}"
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"benchmark failed: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -126,7 +126,7 @@ std::shared_ptr<Value>& Interpreter::visit_array_access(std::shared_ptr<Node> no
         return error;
     }
     algo_call_temp = arr;
-    return dynamic_cast<ArrayValue*>(arr.get())->operator[](std::stoll(index->get_num()));
+    return dynamic_cast<ArrayValue*>(arr.get())->operator[](index->as_int());
 }
 
 std::shared_ptr<Value> Interpreter::visit_array_assign(std::shared_ptr<Node> node) {
@@ -214,13 +214,17 @@ std::shared_ptr<Value> Interpreter::visit_for(std::shared_ptr<Node> node) {
     std::shared_ptr<Value> end_value = visit(child[1]);
     if(end_value->get_type() == VALUE_ERROR) return end_value;
     std::function<bool(std::shared_ptr<Value>, std::shared_ptr<Value>)> condition;
-    if(stod(step->get_num()) > 0) {
+    if(step->as_double() > 0) {
         condition = [](std::shared_ptr<Value> i, std::shared_ptr<Value> end) -> bool {
-            return std::stoll((i <= end)->get_num()) == 1;
+            if (i->get_type() == VALUE_FLOAT || end->get_type() == VALUE_FLOAT)
+                return i->as_double() <= end->as_double();
+            return i->as_int() <= end->as_int();
         };
-    } else if(std::stod(step->get_num()) < 0) {
+    } else if(step->as_double() < 0) {
         condition = [](std::shared_ptr<Value> i, std::shared_ptr<Value> end) -> bool {
-            return std::stoll((i >= end)->get_num()) == 1;
+            if (i->get_type() == VALUE_FLOAT || end->get_type() == VALUE_FLOAT)
+                return i->as_double() >= end->as_double();
+            return i->as_int() >= end->as_int();
         };
     } else {
         return std::make_shared<ErrorValue>(VALUE_ERROR, "Infinite for loop\n");
@@ -251,7 +255,7 @@ std::shared_ptr<Value> Interpreter::visit_for(std::shared_ptr<Node> node) {
 std::shared_ptr<Value> Interpreter::visit_while(std::shared_ptr<Node> node) {
     NodeList child = node->get_child();
     ValueList ret;
-    while(std::stoll(visit(child[0])->get_num()) == 1) {
+    while(visit(child[0])->as_int() == 1) {
         if(child.size() == 2) {
             ret.push_back(visit(child[1]));
             if(ret.back()->get_type() == VALUE_ERROR) 
@@ -282,7 +286,7 @@ std::shared_ptr<Value> Interpreter::visit_repeat(std::shared_ptr<Node> node) {
                     return ret;
             }
         }
-    } while(std::stoll(visit(child[0])->get_num()) == 0);
+    } while(visit(child[0])->as_int() == 0);
     return std::make_shared<ArrayValue>(ret);
 }
 

--- a/src/pseudo.cpp
+++ b/src/pseudo.cpp
@@ -12,6 +12,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 /// --------------------
@@ -23,6 +24,12 @@ std::ostream &operator<<(std::ostream &out, Value &number) {
   return out;
 }
 
+int64_t Value::as_int() { return std::stoll(get_num()); }
+
+double Value::as_double() { return std::stod(get_num()); }
+
+std::string Value::as_string() { return get_num(); }
+
 template <typename T> std::string TypedValue<T>::get_num() {
   std::stringstream ss;
   std::string ret;
@@ -33,6 +40,40 @@ template <typename T> std::string TypedValue<T>::get_num() {
     ret = value;
   }
   return ret;
+}
+
+template <typename T> int64_t TypedValue<T>::as_int() {
+  if constexpr (std::is_same_v<T, int64_t>) {
+    return value;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return static_cast<int64_t>(value);
+  } else {
+    if (value.empty()) {
+      return 0;
+    }
+    return std::stoll(value);
+  }
+}
+
+template <typename T> double TypedValue<T>::as_double() {
+  if constexpr (std::is_same_v<T, double>) {
+    return value;
+  } else if constexpr (std::is_same_v<T, int64_t>) {
+    return static_cast<double>(value);
+  } else {
+    if (value.empty()) {
+      return 0.0;
+    }
+    return std::stod(value);
+  }
+}
+
+template <typename T> std::string TypedValue<T>::as_string() {
+  if constexpr (std::is_same_v<T, std::string>) {
+    return value;
+  } else {
+    return get_num();
+  }
 }
 
 template <typename T> std::string TypedValue<T>::repr() {
@@ -225,7 +266,7 @@ std::shared_ptr<Value> BoundMethodValue::execute(NodeList args,
       }
       long long new_size;
       try {
-        new_size = std::stoll(new_size_val->get_num());
+        new_size = new_size_val->as_int();
       } catch (const std::out_of_range &oor) {
         return std::make_shared<ErrorValue>(VALUE_ERROR,
                                             "Resize argument out of range\n");
@@ -364,13 +405,13 @@ std::shared_ptr<Value> operator+(std::shared_ptr<Value> a,
                                  std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<double>>(
-        VALUE_FLOAT, std::stod(a->get_num()) + std::stod(b->get_num()));
+        VALUE_FLOAT, a->as_double() + b->as_double());
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) + std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() + b->as_int());
   else if (a->get_type() == VALUE_STRING && b->get_type() == VALUE_STRING)
     return std::make_shared<TypedValue<std::string>>(
-        VALUE_STRING, a->get_num() + b->get_num());
+        VALUE_STRING, a->as_string() + b->as_string());
   else
     return std::make_shared<ErrorValue>(
         VALUE_ERROR, Color(0xFF, 0x39, 0x6E).get() +
@@ -382,10 +423,10 @@ std::shared_ptr<Value> operator-(std::shared_ptr<Value> a,
                                  std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<double>>(
-        VALUE_FLOAT, std::stod(a->get_num()) - std::stod(b->get_num()));
+        VALUE_FLOAT, a->as_double() - b->as_double());
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) - std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() - b->as_int());
   else
     return std::make_shared<ErrorValue>(
         VALUE_ERROR,
@@ -397,13 +438,13 @@ std::shared_ptr<Value> operator*(std::shared_ptr<Value> a,
                                  std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<double>>(
-        VALUE_FLOAT, std::stod(a->get_num()) * std::stod(b->get_num()));
+        VALUE_FLOAT, a->as_double() * b->as_double());
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) * std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() * b->as_int());
   else if (a->get_type() == VALUE_STRING && b->get_type() == VALUE_INT) {
-    std::string ret, str_a{a->get_num()};
-    int64_t times{stoll(b->get_num())};
+    std::string ret, str_a{a->as_string()};
+    int64_t times{b->as_int()};
     for (int i{0}; i < times; ++i)
       ret += str_a;
     return std::make_shared<TypedValue<std::string>>(VALUE_STRING, ret);
@@ -416,16 +457,16 @@ std::shared_ptr<Value> operator*(std::shared_ptr<Value> a,
 
 std::shared_ptr<Value> operator/(std::shared_ptr<Value> a,
                                  std::shared_ptr<Value> b) {
-  if (std::stod(b->get_num()) == 0.0)
+  if (b->as_double() == 0.0)
     return std::make_shared<ErrorValue>(VALUE_ERROR,
                                         Color(0xFF, 0x39, 0x6E).get() +
                                             "Runtime ERROR: DIV by 0\n" RESET);
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<double>>(
-        VALUE_FLOAT, std::stod(a->get_num()) / std::stod(b->get_num()));
+        VALUE_FLOAT, a->as_double() / b->as_double());
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) / std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() / b->as_int());
   else
     return std::make_shared<ErrorValue>(
         VALUE_ERROR,
@@ -440,79 +481,79 @@ std::shared_ptr<Value> operator%(std::shared_ptr<Value> a,
         VALUE_ERROR, Color(0xFF, 0x39, 0x6E).get() +
                          "Cannot apply \"%\" operation on float\n" RESET);
   return std::make_shared<TypedValue<int64_t>>(
-      VALUE_INT, std::stoll(a->get_num()) % std::stoll(b->get_num()));
+      VALUE_INT, a->as_int() % b->as_int());
 }
 
 std::shared_ptr<Value> operator==(std::shared_ptr<Value> a,
                                   std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stod(a->get_num()) == std::stod(b->get_num()));
+        VALUE_INT, a->as_double() == b->as_double());
   else
     return std::make_shared<TypedValue<int64_t>>(VALUE_INT,
-                                                 a->get_num() == b->get_num());
+                                                 a->as_string() == b->as_string());
 }
 
 std::shared_ptr<Value> operator!=(std::shared_ptr<Value> a,
                                   std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stod(a->get_num()) != std::stod(b->get_num()));
+        VALUE_INT, a->as_double() != b->as_double());
   else
     return std::make_shared<TypedValue<int64_t>>(VALUE_INT,
-                                                 a->get_num() != b->get_num());
+                                                 a->as_string() != b->as_string());
 }
 
 std::shared_ptr<Value> operator<(std::shared_ptr<Value> a,
                                  std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stod(a->get_num()) < std::stod(b->get_num()));
+        VALUE_INT, a->as_double() < b->as_double());
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) < std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() < b->as_int());
   else
     return std::make_shared<TypedValue<int64_t>>(VALUE_INT,
-                                                 a->get_num() < b->get_num());
+                                                 a->as_string() < b->as_string());
 }
 
 std::shared_ptr<Value> operator>(std::shared_ptr<Value> a,
                                  std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stod(a->get_num()) > std::stod(b->get_num()));
+        VALUE_INT, a->as_double() > b->as_double());
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) > std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() > b->as_int());
   else
     return std::make_shared<TypedValue<int64_t>>(VALUE_INT,
-                                                 a->get_num() > b->get_num());
+                                                 a->as_string() > b->as_string());
 }
 
 std::shared_ptr<Value> operator<=(std::shared_ptr<Value> a,
                                   std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stod(a->get_num()) <= std::stod(b->get_num()));
+        VALUE_INT, a->as_double() <= b->as_double());
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) <= std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() <= b->as_int());
   else
     return std::make_shared<TypedValue<int64_t>>(VALUE_INT,
-                                                 a->get_num() <= b->get_num());
+                                                 a->as_string() <= b->as_string());
 }
 
 std::shared_ptr<Value> operator>=(std::shared_ptr<Value> a,
                                   std::shared_ptr<Value> b) {
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stod(a->get_num()) >= std::stod(b->get_num()));
+        VALUE_INT, a->as_double() >= b->as_double());
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) >= std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() >= b->as_int());
   else
     return std::make_shared<TypedValue<int64_t>>(VALUE_INT,
-                                                 a->get_num() >= b->get_num());
+                                                 a->as_string() >= b->as_string());
 }
 
 std::shared_ptr<Value> operator&&(std::shared_ptr<Value> a,
@@ -520,14 +561,14 @@ std::shared_ptr<Value> operator&&(std::shared_ptr<Value> a,
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<int64_t>>(
         VALUE_INT,
-        std::stod(a->get_num()) != 0 && std::stod(b->get_num()) != 0);
+        a->as_double() != 0 && b->as_double() != 0);
   else if (a->get_type() == VALUE_INT && b->get_type() == VALUE_INT)
     return std::make_shared<TypedValue<int64_t>>(
         VALUE_INT,
-        std::stoll(a->get_num()) != 0 && std::stoll(b->get_num()) != 0);
+        a->as_int() != 0 && b->as_int() != 0);
   else
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) && std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() && b->as_int());
 }
 
 std::shared_ptr<Value> operator||(std::shared_ptr<Value> a,
@@ -535,43 +576,43 @@ std::shared_ptr<Value> operator||(std::shared_ptr<Value> a,
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<int64_t>>(
         VALUE_INT,
-        std::stod(a->get_num()) != 0 || std::stod(b->get_num()) != 0);
+        a->as_double() != 0 || b->as_double() != 0);
   else
     return std::make_shared<TypedValue<int64_t>>(
-        VALUE_INT, std::stoll(a->get_num()) || std::stoll(b->get_num()));
+        VALUE_INT, a->as_int() || b->as_int());
 }
 
 std::shared_ptr<Value> operator-(std::shared_ptr<Value> a) {
   if (a->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<double>>(VALUE_FLOAT,
-                                                0 - stod(a->get_num()));
+                                                0 - a->as_double());
   else
     return std::make_shared<TypedValue<int64_t>>(VALUE_INT,
-                                                 0 - stoll(a->get_num()));
+                                                 0 - a->as_int());
 }
 
 std::shared_ptr<Value> operator!(std::shared_ptr<Value> a) {
   if (a->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<double>>(VALUE_FLOAT,
-                                                stod(a->get_num()) == 0);
+                                                a->as_double() == 0);
   else
     return std::make_shared<TypedValue<int64_t>>(VALUE_INT,
-                                                 stoll(a->get_num()) == 0);
+                                                 a->as_int() == 0);
 }
 
 std::shared_ptr<Value> pow(std::shared_ptr<Value> a, std::shared_ptr<Value> b) {
-  if (std::stod(a->get_num()) == 0.0 && std::stod(b->get_num()) == 0.0)
+  if (a->as_double() == 0.0 && b->as_double() == 0.0)
     return std::make_shared<ErrorValue>(
         VALUE_ERROR,
         Color(0xFF, 0x39, 0x6E).get() + "Runtime ERROR: 0 to the 0\n" RESET);
   if (a->get_type() == VALUE_FLOAT || b->get_type() == VALUE_FLOAT)
     return std::make_shared<TypedValue<double>>(
         VALUE_FLOAT,
-        std::pow(std::stod(a->get_num()), std::stod(b->get_num())));
+        std::pow(a->as_double(), b->as_double()));
   else
     return std::make_shared<TypedValue<int64_t>>(
         VALUE_INT,
-        std::pow(std::stoll(a->get_num()), std::stoll(b->get_num())));
+        std::pow(a->as_int(), b->as_int()));
 }
 
 std::shared_ptr<Value> InstanceValue::get_member(const std::string &name, std::shared_ptr<Value> self) {

--- a/src/pseudo.cpp
+++ b/src/pseudo.cpp
@@ -48,9 +48,6 @@ template <typename T> int64_t TypedValue<T>::as_int() {
   } else if constexpr (std::is_same_v<T, double>) {
     return static_cast<int64_t>(value);
   } else {
-    if (value.empty()) {
-      return 0;
-    }
     return std::stoll(value);
   }
 }
@@ -61,9 +58,6 @@ template <typename T> double TypedValue<T>::as_double() {
   } else if constexpr (std::is_same_v<T, int64_t>) {
     return static_cast<double>(value);
   } else {
-    if (value.empty()) {
-      return 0.0;
-    }
     return std::stod(value);
   }
 }

--- a/src/value.h
+++ b/src/value.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <memory>
 #include <map>
+#include <cstdint>
 #include "node.h"
 
 const std::string VALUE_NONE{"NONE"};
@@ -38,6 +39,9 @@ public:
     virtual std::string get_num() { return type;}
     virtual std::string repr() { return type;}
     virtual std::string get_type(){ return type;}
+    virtual int64_t as_int();
+    virtual double as_double();
+    virtual std::string as_string();
     virtual std::shared_ptr<Value> execute(NodeList args = {}, SymbolTable *parent = nullptr)
         { return std::make_shared<Value>();};
     friend std::ostream& operator<<(std::ostream &out, Value &token);
@@ -55,6 +59,9 @@ public:
         : Value(_type), value(_value) {}
     std::string get_num() override;
     std::string repr() override;
+    int64_t as_int() override;
+    double as_double() override;
+    std::string as_string() override;
 
 protected:
     T value;

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -8,6 +8,7 @@
 #include <interpreter.h>
 #include <pseudo.h>
 #include <memory>
+#include <stdexcept>
 
 // Token Tests
 TEST(TokenTest, EmptyTokenInTypeNone) {
@@ -239,6 +240,10 @@ TEST(InterpreterTest, TestBuiltin) {
     check_interpreter("int(\"123\")", "123", VALUE_INT);
     check_interpreter("float(\"12.34\")", "12.34", VALUE_FLOAT);
     check_interpreter("string(123)", "123", VALUE_STRING);
+}
+
+TEST(InterpreterTest, TestInvalidNumericString) {
+    EXPECT_THROW(check_interpreter("\"\" + 1.0", "IGNORE", "ANY"), std::invalid_argument);
 }
 
 TEST(InterpreterTest, TestAssignment) {


### PR DESCRIPTION
## Summary
- add a Python 3.14 comparison benchmark suite covering CPU, recursion, calls, arrays, stack-like operations, and string concatenation
- optimize numeric and string value access to avoid repeated string conversion in interpreter hot paths
- document the latest local benchmark results

## Validation
- `make clean && make test`
- `python3.14 benchmark/run_benchmarks.py --iterations 3 --warmups 1`

## Benchmark Snapshot
Pseudo slowdown versus Python improved across the included local benchmarks. Final local results ranged from `1.7x` slower for `string_concat` to `8.4x` slower for `recursive_fib`.
