### PR TITLE
perf: add adaptive jit and call optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VPATH = src
 CC = g++
 CPPFLAGS = -std=c++17 -O2
 TARGET = shell
-SRCS = src/color.cpp src/position.cpp src/token.cpp src/node.cpp src/parser.cpp src/lexer.cpp src/symboltable.cpp src/interpreter.cpp src/pseudo.cpp src/shell.cpp src/error.cpp
+SRCS = src/color.cpp src/position.cpp src/token.cpp src/node.cpp src/parser.cpp src/lexer.cpp src/symboltable.cpp src/jit.cpp src/interpreter.cpp src/pseudo.cpp src/shell.cpp src/error.cpp
 BUILD_DIR = build
 OBJS = $(SRCS:src/%.cpp=$(BUILD_DIR)/%.o)
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -20,20 +20,23 @@ program, verifies that stdout matches, then reports median wall time across the
 requested iterations. On macOS it also reports peak resident memory using
 `/usr/bin/time -l`.
 
-Latest local result on Python 3.14.5, 3 iterations, 1 warmup:
+Latest local result on Python 3.14.5, 5 iterations, 1 warmup, with adaptive
+numeric expression JIT enabled:
 
 | benchmark | output | pseudo | Python 3.14 | slowdown | pseudo RSS | Python RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| cpu_arithmetic | 9599988 | 0.2205s | 0.0314s | 7.0x | 27.6 MiB | 14.5 MiB |
-| recursive_fib | 46368 | 0.1994s | 0.0238s | 8.4x | 2.2 MiB | 14.5 MiB |
-| function_calls | 982568 | 0.0997s | 0.0238s | 4.2x | 9.7 MiB | 14.4 MiB |
-| array_memory | 25194337 | 0.0907s | 0.0260s | 3.5x | 16.3 MiB | 15.9 MiB |
-| array_push_pop | 24896907 | 0.1011s | 0.0255s | 4.0x | 15.5 MiB | 16.1 MiB |
-| string_concat | 20000 | 0.0406s | 0.0236s | 1.7x | 225.0 MiB | 14.6 MiB |
+| cpu_arithmetic | 9599988 | 0.0538s | 0.0329s | 1.6x | 27.7 MiB | 14.5 MiB |
+| recursive_fib | 46368 | 0.2218s | 0.0241s | 9.2x | 2.4 MiB | 14.5 MiB |
+| function_calls | 982568 | 0.1118s | 0.0251s | 4.5x | 9.8 MiB | 14.5 MiB |
+| array_memory | 25194337 | 0.0709s | 0.0266s | 2.7x | 15.0 MiB | 15.9 MiB |
+| array_push_pop | 24896907 | 0.1081s | 0.0262s | 4.1x | 14.1 MiB | 16.2 MiB |
+| string_concat | 20000 | 0.0392s | 0.0236s | 1.7x | 225.0 MiB | 14.6 MiB |
 
 Notes:
 
 - Timings include process startup for both executables.
+- The JIT currently specializes hot numeric expressions; it does not compile
+  functions, arrays, strings, structs, imports, or native machine code.
 - `recursive_fib` mainly measures function call and recursion overhead.
 - `array_memory` exercises resize, indexed writes, indexed reads, and integer
   arithmetic.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -21,24 +21,29 @@ requested iterations. On macOS it also reports peak resident memory using
 `/usr/bin/time -l`.
 
 Latest local result on Python 3.14.5, 5 iterations, 1 warmup, with adaptive
-numeric expression JIT enabled:
+numeric expression JIT and shared function-body expression caching enabled:
 
 | benchmark | output | pseudo | Python 3.14 | slowdown | pseudo RSS | Python RSS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| cpu_arithmetic | 9599988 | 0.0538s | 0.0329s | 1.6x | 27.7 MiB | 14.5 MiB |
-| recursive_fib | 46368 | 0.2218s | 0.0241s | 9.2x | 2.4 MiB | 14.5 MiB |
-| function_calls | 982568 | 0.1118s | 0.0251s | 4.5x | 9.8 MiB | 14.5 MiB |
-| array_memory | 25194337 | 0.0709s | 0.0266s | 2.7x | 15.0 MiB | 15.9 MiB |
-| array_push_pop | 24896907 | 0.1081s | 0.0262s | 4.1x | 14.1 MiB | 16.2 MiB |
-| string_concat | 20000 | 0.0392s | 0.0236s | 1.7x | 225.0 MiB | 14.6 MiB |
+| cpu_arithmetic | 9599988 | 0.0531s | 0.0326s | 1.6x | 27.7 MiB | 14.5 MiB |
+| recursive_fib | 46368 | 0.1120s | 0.0242s | 4.6x | 2.3 MiB | 14.5 MiB |
+| function_calls | 982568 | 0.0426s | 0.0446s | 1.0x | 9.8 MiB | 14.6 MiB |
+| array_memory | 25194337 | 0.0879s | 0.0488s | 1.8x | 17.2 MiB | 16.1 MiB |
+| array_push_pop | 24896907 | 0.0843s | 0.0405s | 2.1x | 15.4 MiB | 16.2 MiB |
+| string_concat | 20000 | 0.0572s | 0.0358s | 1.6x | 225.1 MiB | 14.8 MiB |
 
 Notes:
 
 - Timings include process startup for both executables.
 - The JIT currently specializes hot numeric expressions; it does not compile
   functions, arrays, strings, structs, imports, or native machine code.
-- `recursive_fib` mainly measures function call and recursion overhead.
+- `recursive_fib` mainly measures function call and recursion overhead. The
+  shared expression cache lets numeric expressions inside functions become hot
+  across calls.
 - `array_memory` exercises resize, indexed writes, indexed reads, and integer
   arithmetic.
 - `array_push_pop` exercises dynamic array growth and shrinking.
+- Array member calls have a direct native fast path for `push`, `pop`,
+  `resize`, `size`, and `back`, avoiding bound-method allocation and temporary
+  call scopes.
 - `string_concat` prints only the loop count, but still builds the string.

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -9,7 +9,20 @@
 #include <memory>
 #include <functional>
 
+namespace {
+constexpr int JIT_HOT_THRESHOLD = 8;
+
+bool is_jit_root(const std::shared_ptr<Node>& node) {
+    if (!node) return false;
+    return node->get_type() == NODE_BINOP || node->get_type() == NODE_UNARYOP;
+}
+} // namespace
+
 std::shared_ptr<Value> Interpreter::visit(std::shared_ptr<Node> node) {
+    if (std::optional<std::shared_ptr<Value>> jit_result = try_visit_jit(node)) {
+        return *jit_result;
+    }
+
     if(node->get_type() == NODE_VALUE) {
         return visit_number(node);
     }
@@ -62,6 +75,34 @@ std::shared_ptr<Value> Interpreter::visit(std::shared_ptr<Node> node) {
         return visit_return(node);
     }
     return std::make_shared<ErrorValue>(VALUE_ERROR, "Fail to get result\n");
+}
+
+std::optional<std::shared_ptr<Value>> Interpreter::try_visit_jit(const std::shared_ptr<Node>& node) {
+    if (!is_jit_root(node)) {
+        return std::nullopt;
+    }
+
+    JitCacheEntry& entry = jit_cache[node.get()];
+    if (entry.disabled) {
+        return std::nullopt;
+    }
+
+    if (entry.program) {
+        return entry.program->execute(symbol_table);
+    }
+
+    ++entry.hits;
+    if (entry.hits < JIT_HOT_THRESHOLD) {
+        return std::nullopt;
+    }
+
+    entry.program = ExpressionJit::compile(node);
+    if (!entry.program) {
+        entry.disabled = true;
+        return std::nullopt;
+    }
+
+    return entry.program->execute(symbol_table);
 }
 
 std::shared_ptr<Value> Interpreter::visit_number(std::shared_ptr<Node> node) {

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -387,21 +387,31 @@ std::optional<std::shared_ptr<Value>> Interpreter::try_visit_array_method_call(c
     }
 
     NodeList member_child = call_node->get_child();
-    std::shared_ptr<Value> obj = visit(member_child[0]);
-    if (obj->get_type() != VALUE_ARRAY) {
+    const std::string method_name = member_child[1]->get_name();
+    const bool supported_method =
+        method_name == "push" || method_name == "push_back" ||
+        method_name == "pop" || method_name == "pop_back" ||
+        method_name == "resize" || method_name == "size" ||
+        method_name == "back";
+    if (!supported_method || member_child[0]->get_type() != NODE_VARACCESS) {
         return std::nullopt;
     }
 
+    std::shared_ptr<Value> obj = symbol_table.get(member_child[0]->get_name());
+    if (obj->get_type() != VALUE_ARRAY) {
+        return std::nullopt;
+    }
     ArrayValue *arr_obj = dynamic_cast<ArrayValue *>(obj.get());
-    const std::string method_name = member_child[1]->get_name();
     const NodeList& args = algo_call_node->get_args();
+    SymbolTable arg_scope(&symbol_table);
+    Interpreter arg_interpreter(arg_scope);
 
     if (method_name == "push" || method_name == "push_back") {
         if (args.size() != 1) {
             return std::make_shared<ErrorValue>(
                 VALUE_ERROR, "Expect one argument for " + method_name + "\n");
         }
-        std::shared_ptr<Value> arg = visit(args[0]);
+        std::shared_ptr<Value> arg = arg_interpreter.visit(args[0]);
         if (arg->get_type() == VALUE_ERROR) {
             return arg;
         }
@@ -426,7 +436,7 @@ std::optional<std::shared_ptr<Value>> Interpreter::try_visit_array_method_call(c
             return std::make_shared<ErrorValue>(VALUE_ERROR,
                                                 "Expect one argument for resize\n");
         }
-        std::shared_ptr<Value> new_size_val = visit(args[0]);
+        std::shared_ptr<Value> new_size_val = arg_interpreter.visit(args[0]);
         if (new_size_val->get_type() == VALUE_ERROR) {
             return new_size_val;
         }

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -8,6 +8,8 @@
 #include <iostream>
 #include <memory>
 #include <functional>
+#include <stdexcept>
+#include <unordered_map>
 
 namespace {
 constexpr int JIT_HOT_THRESHOLD = 8;
@@ -78,11 +80,13 @@ std::shared_ptr<Value> Interpreter::visit(std::shared_ptr<Node> node) {
 }
 
 std::optional<std::shared_ptr<Value>> Interpreter::try_visit_jit(const std::shared_ptr<Node>& node) {
+    static std::unordered_map<std::size_t, JitCacheEntry> jit_cache;
+
     if (!is_jit_root(node)) {
         return std::nullopt;
     }
 
-    JitCacheEntry& entry = jit_cache[node.get()];
+    JitCacheEntry& entry = jit_cache[node->get_id()];
     if (entry.disabled) {
         return std::nullopt;
     }
@@ -357,15 +361,115 @@ std::shared_ptr<Value> Interpreter::visit_algo_def(std::shared_ptr<Node> node) {
 }
 
 std::shared_ptr<Value> Interpreter::visit_algo_call(std::shared_ptr<Node> node) {
+    if (std::optional<std::shared_ptr<Value>> array_result = try_visit_array_method_call(node)) {
+        return *array_result;
+    }
+
     AlgorithmCallNode *algo_call_node = dynamic_cast<AlgorithmCallNode*>(node.get());
-    NodeList child = node->get_child();
     std::shared_ptr<Node> algo_node = algo_call_node->get_call();
     std::shared_ptr<Value> algo;
     if(algo_node->get_type() == NODE_VARACCESS)
         algo = symbol_table.get(algo_call_node->get_name());
     else
         algo = visit(algo_node);
-    return algo->execute(child, &symbol_table);
+    return algo->execute(algo_call_node->get_args(), &symbol_table);
+}
+
+std::optional<std::shared_ptr<Value>> Interpreter::try_visit_array_method_call(const std::shared_ptr<Node>& node) {
+    AlgorithmCallNode *algo_call_node = dynamic_cast<AlgorithmCallNode*>(node.get());
+    if (!algo_call_node) {
+        return std::nullopt;
+    }
+
+    std::shared_ptr<Node> call_node = algo_call_node->get_call();
+    if (call_node->get_type() != NODE_MEMACCESS) {
+        return std::nullopt;
+    }
+
+    NodeList member_child = call_node->get_child();
+    std::shared_ptr<Value> obj = visit(member_child[0]);
+    if (obj->get_type() != VALUE_ARRAY) {
+        return std::nullopt;
+    }
+
+    ArrayValue *arr_obj = dynamic_cast<ArrayValue *>(obj.get());
+    const std::string method_name = member_child[1]->get_name();
+    const NodeList& args = algo_call_node->get_args();
+
+    if (method_name == "push" || method_name == "push_back") {
+        if (args.size() != 1) {
+            return std::make_shared<ErrorValue>(
+                VALUE_ERROR, "Expect one argument for " + method_name + "\n");
+        }
+        std::shared_ptr<Value> arg = visit(args[0]);
+        if (arg->get_type() == VALUE_ERROR) {
+            return arg;
+        }
+        arr_obj->push_back(arg);
+        return arr_obj->back();
+    }
+
+    if (method_name == "pop" || method_name == "pop_back") {
+        if (!args.empty()) {
+            return std::make_shared<ErrorValue>(
+                VALUE_ERROR, "Expect zero argument for " + method_name + "\n");
+        }
+        if (arr_obj->empty()) {
+            return std::make_shared<ErrorValue>(
+                VALUE_ERROR, "Cannot " + method_name + " from an empty array\n");
+        }
+        return arr_obj->pop_back();
+    }
+
+    if (method_name == "resize") {
+        if (args.size() != 1) {
+            return std::make_shared<ErrorValue>(VALUE_ERROR,
+                                                "Expect one argument for resize\n");
+        }
+        std::shared_ptr<Value> new_size_val = visit(args[0]);
+        if (new_size_val->get_type() == VALUE_ERROR) {
+            return new_size_val;
+        }
+        if (new_size_val->get_type() != VALUE_INT) {
+            return std::make_shared<ErrorValue>(
+                VALUE_ERROR, "Argument for resize must be an integer\n");
+        }
+        long long new_size;
+        try {
+            new_size = new_size_val->as_int();
+        } catch (const std::out_of_range&) {
+            return std::make_shared<ErrorValue>(VALUE_ERROR,
+                                                "Resize argument out of range\n");
+        }
+        if (new_size < 0) {
+            return std::make_shared<ErrorValue>(
+                VALUE_ERROR, "Resize argument cannot be negative\n");
+        }
+        arr_obj->resize(static_cast<int>(new_size));
+        return obj;
+    }
+
+    if (method_name == "size") {
+        if (!args.empty()) {
+            return std::make_shared<ErrorValue>(VALUE_ERROR,
+                                                "Expect zero argument for size\n");
+        }
+        return arr_obj->size();
+    }
+
+    if (method_name == "back") {
+        if (!args.empty()) {
+            return std::make_shared<ErrorValue>(VALUE_ERROR,
+                                                "Expect zero arguments for back\n");
+        }
+        if (arr_obj->empty()) {
+            return std::make_shared<ErrorValue>(
+                VALUE_ERROR, "Cannot call back on an empty array\n");
+        }
+        return arr_obj->back();
+    }
+
+    return std::nullopt;
 }
 
 std::shared_ptr<Value> Interpreter::bin_op(

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -12,7 +12,6 @@
 #include "jit.h"
 #include <memory>
 #include <optional>
-#include <unordered_map>
 
 class Interpreter {
 public:
@@ -47,10 +46,10 @@ protected:
     };
 
     std::optional<std::shared_ptr<Value>> try_visit_jit(const std::shared_ptr<Node>& node);
+    std::optional<std::shared_ptr<Value>> try_visit_array_method_call(const std::shared_ptr<Node>& node);
 
     SymbolTable &symbol_table;
     std::shared_ptr<Value> error, algo_call_temp;
-    std::unordered_map<const Node*, JitCacheEntry> jit_cache;
 };
 
 #endif

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -9,7 +9,10 @@
 #include "value.h"
 #include "node.h"
 #include "token.h"
+#include "jit.h"
 #include <memory>
+#include <optional>
+#include <unordered_map>
 
 class Interpreter {
 public:
@@ -37,8 +40,17 @@ public:
     std::shared_ptr<Value> bin_op(std::shared_ptr<Value>, std::shared_ptr<Value>, std::shared_ptr<Token>);
     std::shared_ptr<Value> unary_op(std::shared_ptr<Value>, std::shared_ptr<Token>);
 protected:
+    struct JitCacheEntry {
+        int hits{0};
+        bool disabled{false};
+        std::optional<JitProgram> program;
+    };
+
+    std::optional<std::shared_ptr<Value>> try_visit_jit(const std::shared_ptr<Node>& node);
+
     SymbolTable &symbol_table;
     std::shared_ptr<Value> error, algo_call_temp;
+    std::unordered_map<const Node*, JitCacheEntry> jit_cache;
 };
 
 #endif

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -1,0 +1,277 @@
+/// --------------------
+/// Adaptive expression JIT
+/// --------------------
+
+#include "jit.h"
+#include "color.h"
+#include "token.h"
+#include <cmath>
+
+namespace {
+
+struct JitNumber {
+    bool is_float{false};
+    int64_t int_value{0};
+    double float_value{0.0};
+
+    static JitNumber from_int(int64_t value) {
+        return JitNumber{false, value, static_cast<double>(value)};
+    }
+
+    static JitNumber from_float(double value) {
+        return JitNumber{true, static_cast<int64_t>(value), value};
+    }
+
+    double as_double() const {
+        return is_float ? float_value : static_cast<double>(int_value);
+    }
+
+    int64_t as_int() const {
+        return is_float ? static_cast<int64_t>(float_value) : int_value;
+    }
+};
+
+bool push_binary_op(const std::string& token_type,
+                    const std::string& token_value,
+                    std::vector<JitInstruction>& instructions) {
+    if (token_type == TOKEN_ADD) instructions.push_back({JitOp::Add});
+    else if (token_type == TOKEN_SUB) instructions.push_back({JitOp::Sub});
+    else if (token_type == TOKEN_MUL) instructions.push_back({JitOp::Mul});
+    else if (token_type == TOKEN_DIV) instructions.push_back({JitOp::Div});
+    else if (token_type == TOKEN_MOD) instructions.push_back({JitOp::Mod});
+    else if (token_type == TOKEN_POW) instructions.push_back({JitOp::Pow});
+    else if (token_type == TOKEN_EQUAL) instructions.push_back({JitOp::Equal});
+    else if (token_type == TOKEN_NEQ) instructions.push_back({JitOp::NotEqual});
+    else if (token_type == TOKEN_LESS) instructions.push_back({JitOp::Less});
+    else if (token_type == TOKEN_GREATER) instructions.push_back({JitOp::Greater});
+    else if (token_type == TOKEN_LEQ) instructions.push_back({JitOp::LessEqual});
+    else if (token_type == TOKEN_GEQ) instructions.push_back({JitOp::GreaterEqual});
+    else if (token_type == TOKEN_KEYWORD && token_value == "and") instructions.push_back({JitOp::And});
+    else if (token_type == TOKEN_KEYWORD && token_value == "or") instructions.push_back({JitOp::Or});
+    else return false;
+    return true;
+}
+
+bool push_unary_op(const std::string& token_type,
+                   const std::string& token_value,
+                   std::vector<JitInstruction>& instructions) {
+    if (token_type == TOKEN_ADD) return true;
+    if (token_type == TOKEN_SUB) instructions.push_back({JitOp::Negate});
+    else if (token_type == TOKEN_KEYWORD && token_value == "not") instructions.push_back({JitOp::Not});
+    else return false;
+    return true;
+}
+
+bool compile_node(const std::shared_ptr<Node>& node,
+                  std::vector<JitInstruction>& instructions) {
+    if (!node) return false;
+
+    const std::string node_type = node->get_type();
+    if (node_type == NODE_VALUE) {
+        std::shared_ptr<Token> token = node->get_tok();
+        if (token->get_type() == TOKEN_INT) {
+            instructions.push_back({JitOp::PushInt, std::stoll(token->get_value())});
+            return true;
+        }
+        if (token->get_type() == TOKEN_FLOAT) {
+            JitInstruction instruction{JitOp::PushFloat};
+            instruction.float_value = std::stod(token->get_value());
+            instructions.push_back(instruction);
+            return true;
+        }
+        return false;
+    }
+
+    if (node_type == NODE_VARACCESS) {
+        JitInstruction instruction{JitOp::LoadVar};
+        instruction.name = node->get_name();
+        instructions.push_back(instruction);
+        return true;
+    }
+
+    if (node_type == NODE_BINOP) {
+        NodeList child = node->get_child();
+        if (child.size() != 2) return false;
+        if (!compile_node(child[0], instructions)) return false;
+        if (!compile_node(child[1], instructions)) return false;
+        std::shared_ptr<Token> token = node->get_tok();
+        return push_binary_op(token->get_type(), token->get_value(), instructions);
+    }
+
+    if (node_type == NODE_UNARYOP) {
+        NodeList child = node->get_child();
+        if (child.size() != 1) return false;
+        if (!compile_node(child[0], instructions)) return false;
+        std::shared_ptr<Token> token = node->get_tok();
+        return push_unary_op(token->get_type(), token->get_value(), instructions);
+    }
+
+    return false;
+}
+
+std::shared_ptr<Value> to_value(const JitNumber& number) {
+    if (number.is_float) {
+        return std::make_shared<TypedValue<double>>(VALUE_FLOAT, number.float_value);
+    }
+    return std::make_shared<TypedValue<int64_t>>(VALUE_INT, number.int_value);
+}
+
+std::shared_ptr<Value> runtime_error(const std::string& message) {
+    return std::make_shared<ErrorValue>(
+        VALUE_ERROR, Color(0xFF, 0x39, 0x6E).get() + message + RESET);
+}
+
+} // namespace
+
+std::optional<JitProgram> ExpressionJit::compile(const std::shared_ptr<Node>& node) {
+    std::vector<JitInstruction> instructions;
+    if (!compile_node(node, instructions)) {
+        return std::nullopt;
+    }
+    return JitProgram(std::move(instructions));
+}
+
+std::optional<std::shared_ptr<Value>> JitProgram::execute(SymbolTable &symbols) const {
+    std::vector<JitNumber> stack;
+    stack.reserve(instructions.size());
+
+    auto pop = [&stack]() -> std::optional<JitNumber> {
+        if (stack.empty()) return std::nullopt;
+        JitNumber value = stack.back();
+        stack.pop_back();
+        return value;
+    };
+
+    for (const JitInstruction& instruction : instructions) {
+        switch (instruction.op) {
+        case JitOp::PushInt:
+            stack.push_back(JitNumber::from_int(instruction.int_value));
+            break;
+        case JitOp::PushFloat:
+            stack.push_back(JitNumber::from_float(instruction.float_value));
+            break;
+        case JitOp::LoadVar: {
+            std::shared_ptr<Value> value = symbols.get(instruction.name);
+            if (value->get_type() == VALUE_ERROR) return value;
+            if (value->get_type() == VALUE_INT) stack.push_back(JitNumber::from_int(value->as_int()));
+            else if (value->get_type() == VALUE_FLOAT) stack.push_back(JitNumber::from_float(value->as_double()));
+            else return std::nullopt;
+            break;
+        }
+        case JitOp::Add:
+        case JitOp::Sub:
+        case JitOp::Mul:
+        case JitOp::Div:
+        case JitOp::Mod:
+        case JitOp::Pow:
+        case JitOp::Equal:
+        case JitOp::NotEqual:
+        case JitOp::Less:
+        case JitOp::Greater:
+        case JitOp::LessEqual:
+        case JitOp::GreaterEqual:
+        case JitOp::And:
+        case JitOp::Or: {
+            std::optional<JitNumber> rhs = pop();
+            std::optional<JitNumber> lhs = pop();
+            if (!lhs || !rhs) return std::nullopt;
+            const bool use_float = lhs->is_float || rhs->is_float;
+            switch (instruction.op) {
+            case JitOp::Add:
+                stack.push_back(use_float
+                    ? JitNumber::from_float(lhs->as_double() + rhs->as_double())
+                    : JitNumber::from_int(lhs->int_value + rhs->int_value));
+                break;
+            case JitOp::Sub:
+                stack.push_back(use_float
+                    ? JitNumber::from_float(lhs->as_double() - rhs->as_double())
+                    : JitNumber::from_int(lhs->int_value - rhs->int_value));
+                break;
+            case JitOp::Mul:
+                stack.push_back(use_float
+                    ? JitNumber::from_float(lhs->as_double() * rhs->as_double())
+                    : JitNumber::from_int(lhs->int_value * rhs->int_value));
+                break;
+            case JitOp::Div:
+                if (rhs->as_double() == 0.0) return runtime_error("Runtime ERROR: DIV by 0\n");
+                stack.push_back(use_float
+                    ? JitNumber::from_float(lhs->as_double() / rhs->as_double())
+                    : JitNumber::from_int(lhs->int_value / rhs->int_value));
+                break;
+            case JitOp::Mod:
+                if (lhs->is_float || rhs->is_float) return std::nullopt;
+                stack.push_back(JitNumber::from_int(lhs->int_value % rhs->int_value));
+                break;
+            case JitOp::Pow:
+                if (lhs->as_double() == 0.0 && rhs->as_double() == 0.0) {
+                    return runtime_error("Runtime ERROR: 0 to the 0\n");
+                }
+                stack.push_back(use_float
+                    ? JitNumber::from_float(std::pow(lhs->as_double(), rhs->as_double()))
+                    : JitNumber::from_int(static_cast<int64_t>(std::pow(lhs->int_value, rhs->int_value))));
+                break;
+            case JitOp::Equal:
+                stack.push_back(JitNumber::from_int(use_float
+                    ? lhs->as_double() == rhs->as_double()
+                    : lhs->int_value == rhs->int_value));
+                break;
+            case JitOp::NotEqual:
+                stack.push_back(JitNumber::from_int(use_float
+                    ? lhs->as_double() != rhs->as_double()
+                    : lhs->int_value != rhs->int_value));
+                break;
+            case JitOp::Less:
+                stack.push_back(JitNumber::from_int(use_float
+                    ? lhs->as_double() < rhs->as_double()
+                    : lhs->int_value < rhs->int_value));
+                break;
+            case JitOp::Greater:
+                stack.push_back(JitNumber::from_int(use_float
+                    ? lhs->as_double() > rhs->as_double()
+                    : lhs->int_value > rhs->int_value));
+                break;
+            case JitOp::LessEqual:
+                stack.push_back(JitNumber::from_int(use_float
+                    ? lhs->as_double() <= rhs->as_double()
+                    : lhs->int_value <= rhs->int_value));
+                break;
+            case JitOp::GreaterEqual:
+                stack.push_back(JitNumber::from_int(use_float
+                    ? lhs->as_double() >= rhs->as_double()
+                    : lhs->int_value >= rhs->int_value));
+                break;
+            case JitOp::And:
+                stack.push_back(JitNumber::from_int(lhs->as_double() != 0.0 && rhs->as_double() != 0.0));
+                break;
+            case JitOp::Or:
+                stack.push_back(JitNumber::from_int(lhs->as_double() != 0.0 || rhs->as_double() != 0.0));
+                break;
+            default:
+                return std::nullopt;
+            }
+            break;
+        }
+        case JitOp::Negate: {
+            std::optional<JitNumber> value = pop();
+            if (!value) return std::nullopt;
+            stack.push_back(value->is_float
+                ? JitNumber::from_float(-value->float_value)
+                : JitNumber::from_int(-value->int_value));
+            break;
+        }
+        case JitOp::Not: {
+            std::optional<JitNumber> value = pop();
+            if (!value) return std::nullopt;
+            if (value->is_float) {
+                stack.push_back(JitNumber::from_float(value->as_double() == 0.0));
+            } else {
+                stack.push_back(JitNumber::from_int(value->as_int() == 0));
+            }
+            break;
+        }
+        }
+    }
+
+    if (stack.size() != 1) return std::nullopt;
+    return to_value(stack.back());
+}

--- a/src/jit.h
+++ b/src/jit.h
@@ -1,0 +1,63 @@
+/// --------------------
+/// Adaptive expression JIT
+/// --------------------
+
+#ifndef JIT_H
+#define JIT_H
+
+#include "node.h"
+#include "symboltable.h"
+#include "value.h"
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+enum class JitOp {
+    PushInt,
+    PushFloat,
+    LoadVar,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Pow,
+    Equal,
+    NotEqual,
+    Less,
+    Greater,
+    LessEqual,
+    GreaterEqual,
+    And,
+    Or,
+    Negate,
+    Not,
+};
+
+struct JitInstruction {
+    JitOp op;
+    int64_t int_value{0};
+    double float_value{0.0};
+    std::string name;
+};
+
+class JitProgram {
+public:
+    explicit JitProgram(std::vector<JitInstruction> _instructions)
+        : instructions(std::move(_instructions)) {}
+
+    std::optional<std::shared_ptr<Value>> execute(SymbolTable &symbols) const;
+
+private:
+    std::vector<JitInstruction> instructions;
+};
+
+class ExpressionJit {
+public:
+    static std::optional<JitProgram> compile(const std::shared_ptr<Node>& node);
+};
+
+#endif

--- a/src/node.h
+++ b/src/node.h
@@ -5,6 +5,8 @@
 #ifndef NODE_H
 #define NODE_H
 
+#include <atomic>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -33,6 +35,7 @@ const std::string TAB{"    "};
 
 class Node {
 public:
+    Node() : node_id(next_node_id.fetch_add(1, std::memory_order_relaxed)) {}
     virtual std::string get_node() = 0;
     virtual ~Node() {};
     virtual std::vector<std::shared_ptr<Node>> get_child() { return std::vector<std::shared_ptr<Node>>(0);}
@@ -40,6 +43,10 @@ public:
     virtual std::shared_ptr<Token> get_tok() { return nullptr;}
     virtual TokenList get_toks() { return TokenList(0);}
     virtual std::string get_name() { return "";}
+    std::size_t get_id() const { return node_id;}
+private:
+    inline static std::atomic_size_t next_node_id{1};
+    std::size_t node_id;
 };
 
 using NodeList = std::vector<std::shared_ptr<Node>>;
@@ -200,6 +207,7 @@ public:
         : algo_name(_algo_name), args_name(_args_name), body_node(_body_node) {}
     std::string get_node() override;
     NodeList get_child() override { return body_node;}
+    const NodeList& get_body() const { return body_node;}
     std::string get_type() override { return NODE_ALGODEF;}
     std::shared_ptr<Token> get_tok() override { return algo_name;}
     TokenList get_toks() override { return args_name;}
@@ -216,6 +224,7 @@ public:
         : call_node(_call_node), args(_args) {}
     std::string get_node() override;
     NodeList get_child() override { return args;}
+    const NodeList& get_args() const { return args;}
     std::string get_type() override { return NODE_ALGOCALL;}
     std::shared_ptr<Token> get_tok() override { return nullptr;}
     std::string get_name() override { return call_node->get_name();}

--- a/src/pseudo.cpp
+++ b/src/pseudo.cpp
@@ -129,21 +129,20 @@ std::shared_ptr<Value> &ArrayValue::operator[](int p) {
   return error;
 }
 
-std::shared_ptr<Value> BaseAlgoValue::set_args(NodeList &args, SymbolTable &sym,
+std::shared_ptr<Value> BaseAlgoValue::set_args(const NodeList &args, SymbolTable &sym,
                                                Interpreter &interpreter) {
-  if (args.size() < value->get_toks().size()) {
+  if (args.size() < arg_names.size()) {
     return std::make_shared<ErrorValue>(
         VALUE_ERROR, Color(0xFF, 0x39, 0x6E).get() + "Too few arguments" RESET);
-  } else if (args.size() > value->get_toks().size()) {
+  } else if (args.size() > arg_names.size()) {
     return std::make_shared<ErrorValue>(VALUE_ERROR,
                                         Color(0xFF, 0x39, 0x6E).get() +
                                             "Too many arguments" RESET);
   }
 
-  TokenList args_name = value->get_toks();
   for (int i = 0; i < args.size(); ++i) {
     std::shared_ptr<Value> v = interpreter.visit(args[i]);
-    sym.set(args_name[i]->get_value(), v);
+    sym.set(arg_names[i], v);
   }
   return std::make_shared<Value>();
 }
@@ -169,7 +168,7 @@ private:
     SymbolTable& sym;
 };
 
-std::shared_ptr<Value> AlgoValue::execute(NodeList args, SymbolTable *parent) {
+std::shared_ptr<Value> AlgoValue::execute(const NodeList& args, SymbolTable *parent) {
   SymbolTable sym(parent);
   ScopeCleaner cleaner(sym);
   Interpreter interpreter(sym);
@@ -177,7 +176,8 @@ std::shared_ptr<Value> AlgoValue::execute(NodeList args, SymbolTable *parent) {
   if (ret->get_type() == VALUE_ERROR)
     return ret;
 
-  NodeList algo_body = value->get_child();
+  AlgorithmDefNode* algo_node = dynamic_cast<AlgorithmDefNode*>(value.get());
+  const NodeList& algo_body = algo_node->get_body();
 
   for (int i = 0; i < algo_body.size(); ++i) {
     ret = interpreter.visit(algo_body[i]);
@@ -188,7 +188,7 @@ std::shared_ptr<Value> AlgoValue::execute(NodeList args, SymbolTable *parent) {
   return ret;
 }
 
-std::shared_ptr<Value> BuiltinAlgoValue::execute(NodeList args,
+std::shared_ptr<Value> BuiltinAlgoValue::execute(const NodeList& args,
                                                  SymbolTable *parent) {
   SymbolTable sym(parent);
   ScopeCleaner cleaner(sym);
@@ -196,9 +196,8 @@ std::shared_ptr<Value> BuiltinAlgoValue::execute(NodeList args,
   std::shared_ptr<Value> ret{set_args(args, sym, interpreter)};
   if (ret->get_type() == VALUE_ERROR)
     return ret;
-  TokenList args_name = value->get_toks();
   if (algo_name == "print") {
-    return execute_print(sym.get(args_name[0]->get_value())->get_num());
+    return execute_print(sym.get(arg_names[0])->get_num());
   } else if (algo_name == "read") {
     return execute_read();
   } else if (algo_name == "read_line") {
@@ -210,16 +209,16 @@ std::shared_ptr<Value> BuiltinAlgoValue::execute(NodeList args,
   } else if (algo_name == "quit") {
     exit(0);
   } else if (algo_name == "int") {
-    return execute_int(sym.get(args_name[0]->get_value())->get_num());
+    return execute_int(sym.get(arg_names[0])->get_num());
   } else if (algo_name == "float") {
-    return execute_float(sym.get(args_name[0]->get_value())->get_num());
+    return execute_float(sym.get(arg_names[0])->get_num());
   } else if (algo_name == "string") {
-    return execute_string(sym.get(args_name[0]->get_value())->get_num());
+    return execute_string(sym.get(arg_names[0])->get_num());
   }
   return ret;
 }
 
-std::shared_ptr<Value> BoundMethodValue::execute(NodeList args,
+std::shared_ptr<Value> BoundMethodValue::execute(const NodeList& args,
                                                  SymbolTable *parent) {
   if (obj->get_type() == VALUE_ARRAY) {
     ArrayValue *arr_obj = dynamic_cast<ArrayValue *>(obj.get());
@@ -320,7 +319,8 @@ std::shared_ptr<Value> BoundMethodValue::execute(NodeList args,
         return ret;
 
       // Execute body
-      NodeList algo_body = algo_val->get_node_ptr()->get_child();
+      AlgorithmDefNode* algo_node = dynamic_cast<AlgorithmDefNode*>(algo_val->get_node_ptr().get());
+      const NodeList& algo_body = algo_node->get_body();
 
       std::shared_ptr<Value> res = ret;
       for (int i = 0; i < algo_body.size(); ++i) {
@@ -643,7 +643,7 @@ void InstanceValue::set_member(const std::string &name,
     members[name] = val; // Just set it for now.
   }
 }
-std::shared_ptr<Value> StructValue::execute(NodeList args,
+std::shared_ptr<Value> StructValue::execute(const NodeList& args,
                                             SymbolTable *parent) {
   // Constructor call
   std::shared_ptr<InstanceValue> instance =

--- a/src/value.h
+++ b/src/value.h
@@ -42,7 +42,7 @@ public:
     virtual int64_t as_int();
     virtual double as_double();
     virtual std::string as_string();
-    virtual std::shared_ptr<Value> execute(NodeList args = {}, SymbolTable *parent = nullptr)
+    virtual std::shared_ptr<Value> execute(const NodeList& args = {}, SymbolTable *parent = nullptr)
         { return std::make_shared<Value>();};
     friend std::ostream& operator<<(std::ostream &out, Value &token);
     
@@ -72,14 +72,19 @@ using ErrorValue = TypedValue<std::string>;
 class BaseAlgoValue: public Value {
 public:
     BaseAlgoValue(const std::string &_algo_name, std::shared_ptr<Node> _value) 
-        : Value(VALUE_ALGO), value(_value), algo_name(_algo_name) {}
+        : Value(VALUE_ALGO), value(_value), algo_name(_algo_name) {
+        for (const auto& tok : value->get_toks()) {
+            arg_names.push_back(tok->get_value());
+        }
+    }
     std::string get_num() override { return algo_name;}
-    virtual std::shared_ptr<Value> set_args(NodeList&, SymbolTable&, Interpreter&);
+    virtual std::shared_ptr<Value> set_args(const NodeList&, SymbolTable&, Interpreter&);
     std::string repr() override { return get_num();}
 
 protected:
     std::string algo_name;
     std::shared_ptr<Node> value;
+    std::vector<std::string> arg_names;
 };
 
 class AlgoValue: public BaseAlgoValue {
@@ -88,7 +93,7 @@ public:
         : BaseAlgoValue(_algo_name, _value) {}
     std::string get_num() override { return algo_name;}
     std::string repr() override { return get_num();}
-    std::shared_ptr<Value> execute(NodeList args = {}, SymbolTable *parent = nullptr) override;
+    std::shared_ptr<Value> execute(const NodeList& args = {}, SymbolTable *parent = nullptr) override;
     friend class BoundMethodValue;
     // Expose value for friends/derived or public use if needed for method binding
     std::shared_ptr<Node> get_node_ptr() { return value; }
@@ -100,7 +105,7 @@ public:
     BuiltinAlgoValue(const std::string &_algo_name, std::shared_ptr<Node> _value) 
         : BaseAlgoValue(_algo_name, _value) {}
     std::string get_num() override { return algo_name;}
-    std::shared_ptr<Value> execute(NodeList args = {}, SymbolTable *parent = nullptr) override;
+    std::shared_ptr<Value> execute(const NodeList& args = {}, SymbolTable *parent = nullptr) override;
     std::shared_ptr<Value> execute_print(const std::string&);
     std::shared_ptr<Value> execute_read();
     std::shared_ptr<Value> execute_read_line();
@@ -116,7 +121,7 @@ class BoundMethodValue : public Value {
 public:
     BoundMethodValue(std::shared_ptr<Value> _obj, std::string _method_name)
         : Value(VALUE_ALGO), obj(_obj), method_name(_method_name) {}
-    std::shared_ptr<Value> execute(NodeList args = {}, SymbolTable *parent = nullptr) override;
+    std::shared_ptr<Value> execute(const NodeList& args = {}, SymbolTable *parent = nullptr) override;
     std::string get_num() override { return method_name; }
     std::string repr() override { return "<Bound Method " + method_name + ">"; }
 protected:
@@ -132,6 +137,7 @@ public:
     std::shared_ptr<Value>& operator[](int p);
     void push_back(std::shared_ptr<Value>);
     std::shared_ptr<Value> pop_back();
+    bool empty() const { return value.empty();}
     std::shared_ptr<Value>& size() { return sz = std::make_shared<TypedValue<int64_t>>(VALUE_INT, value.size());};
     std::shared_ptr<Value>& back() { return value.back();};
     std::string repr() override { return get_num();}
@@ -187,7 +193,7 @@ public:
     std::vector<std::string> members;
     std::map<std::string, std::shared_ptr<Value>> methods;
     std::string name;
-    std::shared_ptr<Value> execute(NodeList args = {}, SymbolTable *parent = nullptr) override;
+    std::shared_ptr<Value> execute(const NodeList& args = {}, SymbolTable *parent = nullptr) override;
 };
 
 class InstanceValue : public Value {

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -218,6 +218,17 @@ TEST(InterpreterTest, TestControlFlowWhile) {
     check_interpreter("i <- 0; while i < 5 do i <- i + 1", "{1, 2, 3, 4, 5}", VALUE_ARRAY);
 }
 
+TEST(InterpreterTest, TestHotNumericLoop) {
+    check_interpreter(
+        "i <- 0\n"
+        "acc <- 0\n"
+        "while i < 25 do\n"
+        "    i <- i + 1\n"
+        "    acc <- (acc + (i * 7) % 11) % 1000\n"
+        "acc",
+        "130");
+}
+
 TEST(InterpreterTest, TestControlFlowRepeat) {
     // Repeat Until
     // i <- 0; repeat i <- i + 1 until i = 5

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -245,6 +245,8 @@ TEST(InterpreterTest, TestArray) {
     check_interpreter("a <- {1, 2, 3}; a.push(4)", "4");
     // pop returns popped value -> 3
     check_interpreter("a <- {1, 2, 3}; a.pop()", "3");
+    // Array method arguments are evaluated in a call-local scope.
+    check_interpreter("x <- 1; a <- {}; a.push(x <- 2); x", "1");
 }
 
 TEST(InterpreterTest, TestBuiltin) {


### PR DESCRIPTION
## Summary
- add adaptive numeric expression JIT and share hot expression cache across interpreter instances
- cache algorithm argument metadata and avoid call/body NodeList copies
- add direct native fast path for array methods and refresh benchmark report

## Validation
- make clean && make test
- python3.14 benchmark/run_benchmarks.py --iterations 5 --warmups 1